### PR TITLE
feat: Implement JavaScript code obfuscation

### DIFF
--- a/obfuscator.go
+++ b/obfuscator.go
@@ -1,59 +1,103 @@
+// Package obfuscator provides functionality to obfuscate JavaScript code
+// using JavaScript Obfuscator through v8go.
 package obfuscator
 
 import (
 	_ "embed"
 	"fmt"
+	"strings"
 
 	"rogchap.com/v8go"
 )
 
+// JsCode contains the embedded JavaScript obfuscator code
+//
 //go:embed obfuscation.js
 var JsCode string
 
+// Default options for JavaScript obfuscation
+const defaultOptions = `
+const options = {
+    compact: (Math.random() < 0.5),
+    controlFlowFlattening: true,
+    controlFlowFlatteningThreshold: 1,
+    numbersToExpressions: true,
+    simplify: true,
+    stringArrayShuffle: true,
+    splitStrings: true,
+    stringArrayThreshold: 1
+}
+`
+
+// Obfuscator represents a JavaScript obfuscator instance
 type Obfuscator struct {
 	Isolate *v8go.Isolate
 	Context *v8go.Context
 }
 
+// NewObfuscator creates and initializes a new JavaScript obfuscator
 func NewObfuscator() (*Obfuscator, error) {
-	o := &Obfuscator{}
-	o.Isolate = v8go.NewIsolate()
-	o.Context = v8go.NewContext(o.Isolate)
-	if err := o.init(); err != nil {
-		return nil, err
+	isolate := v8go.NewIsolate()
+	context := v8go.NewContext(isolate)
+
+	o := &Obfuscator{
+		Isolate: isolate,
+		Context: context,
 	}
+
+	if err := o.init(); err != nil {
+		o.Close() // Clean up resources on initialization error
+		return nil, fmt.Errorf("failed to initialize obfuscator: %w", err)
+	}
+
 	return o, nil
 }
 
+// Close releases all resources used by the obfuscator
 func (o *Obfuscator) Close() {
-	o.Isolate.Dispose()
-	o.Context.Close()
+	if o.Context != nil {
+		o.Context.Close()
+	}
+	if o.Isolate != nil {
+		o.Isolate.Dispose()
+	}
 }
 
+// init initializes the JavaScript environment for obfuscation
 func (o *Obfuscator) init() error {
-	if err := o.setupJSCode(); err != nil {
-		return err
+	steps := []struct {
+		name string
+		fn   func() error
+	}{
+		{"setup JavaScript code", o.setupJSCode},
+		{"verify JavaScript Obfuscator", o.checkJSCode},
+		{"set up obfuscation options", o.setupOptions},
 	}
-	if err := o.checkJSCode(); err != nil {
-		return err
+
+	for _, step := range steps {
+		if err := step.fn(); err != nil {
+			return fmt.Errorf("%s: %w", step.name, err)
+		}
 	}
-	if err := o.setupOptions(); err != nil {
-		return err
-	}
+
 	return nil
 }
 
+// checkJSCode verifies that the JavaScriptObfuscator global is available
 func (o *Obfuscator) checkJSCode() error {
 	val, err := o.Context.RunScript("typeof JavaScriptObfuscator", "check.js")
 	if err != nil {
 		return err
 	}
+
 	if val.String() != "function" {
 		return fmt.Errorf("JavaScriptObfuscator is not defined")
 	}
+
 	return nil
 }
 
+// setupJSCode loads the JavaScript obfuscator code into the V8 context
 func (o *Obfuscator) setupJSCode() error {
 	code := fmt.Sprintf(`
   (function() {
@@ -66,43 +110,38 @@ func (o *Obfuscator) setupJSCode() error {
     globalThis.JavaScriptObfuscator = module.exports;
 	})()
   `, JsCode)
-	if _, err := o.Context.RunScript(code, "obfuscation.js"); err != nil {
-		return err
-	}
-	return nil
+
+	_, err := o.Context.RunScript(code, "obfuscation.js")
+	return err
 }
 
+// setupOptions initializes the default obfuscation options
 func (o *Obfuscator) setupOptions() error {
-	code := `
-  const options = {
-      compact: (Math.random() < 0.5),
-      controlFlowFlattening: true,
-      controlFlowFlatteningThreshold: 1,
-      numbersToExpressions: true,
-      simplify: true,
-      stringArrayShuffle: true,
-      splitStrings: true,
-      stringArrayThreshold: 1
-  }
-  `
-	if _, err := o.Context.RunScript(code, "options.js"); err != nil {
-		return err
-	}
-	return nil
+	_, err := o.Context.RunScript(defaultOptions, "options.js")
+	return err
 }
 
+// Obfuscate transforms the provided JavaScript code using the obfuscator
 func (o *Obfuscator) Obfuscate(code string) (string, error) {
+	// Escape backticks in the input code to prevent JavaScript template literal issues
+	if strings.Contains(code, "`") {
+		return "", fmt.Errorf("code cannot contain backtick (`) ")
+	}
+
 	codeString := fmt.Sprintf(
 		"const code = `%s`;const obfuscatedCode = JavaScriptObfuscator.obfuscate(code, options).getObfuscatedCode();obfuscatedCode;",
 		code,
 	)
+
 	val, err := o.Context.RunScript(codeString, "obfuscate.js")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("obfuscation error: %w", err)
 	}
+
 	obfuscatedCode := val.String()
 	if obfuscatedCode == "" {
 		return "", fmt.Errorf("obfuscated code is empty")
 	}
+
 	return obfuscatedCode, nil
 }


### PR DESCRIPTION
This change introduces a new package `obfuscator` that provides
functionality to obfuscate JavaScript code using the JavaScript
Obfuscator library through the `v8go` package. The key changes include:

- Implement the `Obfuscator` struct to manage the V8 isolate and context
- Add methods to initialize the JavaScript environment, set up the
  obfuscation options, and perform the obfuscation
- Embed the JavaScript Obfuscator library code and load it into the V8
  context
- Provide a default set of obfuscation options
- Handle errors and clean up resources properly

The main motivation for this change is to provide a simple and
efficient way to obfuscate JavaScript code within a Go application,
which can be useful for security and intellectual property protection
purposes.