### PR TITLE
feat(obfuscator): create new context for each obfuscation

### DIFF
--- a/obfuscator.go
+++ b/obfuscator.go
@@ -128,12 +128,15 @@ func (o *Obfuscator) Obfuscate(code string) (string, error) {
 		return "", fmt.Errorf("code cannot contain backtick (`) ")
 	}
 
+	ctx := v8go.NewContext(o.Isolate)
+	defer ctx.Close()
+
 	codeString := fmt.Sprintf(
 		"const code = `%s`;const obfuscatedCode = JavaScriptObfuscator.obfuscate(code, options).getObfuscatedCode();obfuscatedCode;",
 		code,
 	)
 
-	val, err := o.Context.RunScript(codeString, "obfuscate.js")
+	val, err := ctx.RunScript(codeString, "obfuscate.js")
 	if err != nil {
 		return "", fmt.Errorf("obfuscation error: %w", err)
 	}


### PR DESCRIPTION
The changes create a new V8 context for each obfuscation operation to
ensure thread-safety and prevent potential issues with shared state.
This is an important change to improve the reliability and robustness
of the obfuscation functionality.