### PR TITLE
feat: Add support for third-party dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "zencoder.enableRepoIndexing": true
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,9 @@ module github.com/naicoi92/obfuscator
 go 1.24.0
 
 require rogchap.com/v8go v0.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 rogchap.com/v8go v0.9.0 h1:wYbUCO4h6fjTamziHrzyrPnpFNuzPpjZY+nfmZjNaew=
 rogchap.com/v8go v0.9.0/go.mod h1:MxgP3pL2MW4dpme/72QRs8sgNMmM0pRc8DPhcuLWPAs=

--- a/obfuscator_test.go
+++ b/obfuscator_test.go
@@ -1,0 +1,46 @@
+package obfuscator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewObfuscator_Success kiểm tra việc tạo obfuscator thành công
+func TestNewObfuscator_Success(t *testing.T) {
+	// Arrange & Act
+	obf, err := NewObfuscator()
+
+	// Assert
+	assert.NoError(t, err, "Không nên có lỗi khi tạo obfuscator")
+	assert.NotNil(t, obf, "Obfuscator không nên là nil")
+}
+
+// TestNewObfuscator_CachedData kiểm tra việc tạo cached data
+func TestNewObfuscator_CachedData(t *testing.T) {
+	// Arrange & Act
+	obf, err := NewObfuscator()
+
+	// Assert
+	require.NoError(t, err, "Không nên có lỗi khi tạo obfuscator")
+	assert.NotNil(t, obf.CachedData, "CachedData không nên là nil")
+}
+
+// TestNewObfuscator_MultipleObfuscations kiểm tra việc sử dụng obfuscator nhiều lần
+func TestNewObfuscator_MultipleObfuscations(t *testing.T) {
+	// Arrange
+	obf, err := NewObfuscator()
+	require.NoError(t, err, "Không nên có lỗi khi tạo obfuscator")
+
+	// Mã JavaScript đơn giản để test
+	jsCode := "function test() { return 'Hello World'; }"
+
+	// Act & Assert
+	// Thực hiện obfuscate nhiều lần
+	for i := 0; i < 3; i++ {
+		result, err := obf.Obfuscate(jsCode)
+		assert.NoError(t, err, "Obfuscation #%d không nên có lỗi", i+1)
+		assert.NotEmpty(t, result, "Kết quả obfuscation #%d không nên rỗng", i+1)
+	}
+}


### PR DESCRIPTION
This commit adds support for the following third-party dependencies:

- github.com/davecgh/go-spew
- github.com/pmezard/go-difflib
- github.com/stretchr/testify

These dependencies are required for the unit tests in the `obfuscator_test.go` file.

The changes include:

- Adding the required dependencies in the `go.mod` file
- Adding the corresponding entries in the `go.sum` file
- Adding a `.vscode/settings.json` file to enable repo indexing for the project

Additionally, this commit includes the implementation of the `obfuscator_test.go` file, which contains three test cases:

1. `TestNewObfuscator_Success`: Ensures that a new obfuscator can be created successfully.
2. `TestNewObfuscator_CachedData`: Verifies that the obfuscator has cached data after creation.
3. `TestNewObfuscator_MultipleObfuscations`: Tests that the obfuscator can be used multiple times to obfuscate JavaScript code.

These test cases help ensure the reliability and correctness of the obfuscator functionality.