### PR TITLE
feat(obfuscator): Increase the number of obfuscation

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,28 @@
+name: Go Test
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          check-latest: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Run tests with race detection
+        run: go test -race -v ./...

--- a/obfuscator_test.go
+++ b/obfuscator_test.go
@@ -38,7 +38,7 @@ func TestNewObfuscator_MultipleObfuscations(t *testing.T) {
 
 	// Act & Assert
 	// Thực hiện obfuscate nhiều lần
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 10; i++ {
 		result, err := obf.Obfuscate(jsCode)
 		assert.NoError(t, err, "Obfuscation #%d không nên có lỗi", i+1)
 		assert.NotEmpty(t, result, "Kết quả obfuscation #%d không nên rỗng", i+1)


### PR DESCRIPTION
iterations and add a GitHub Actions workflow for Go tests

The changes in this commit include:

1. Increasing the number of obfuscation iterations in the
   `TestNewObfuscator_MultipleObfuscations` test from 3 to 10 to
   ensure more thorough testing of the obfuscation functionality.

2. Adding a new GitHub Actions workflow file
   `.github/workflows/go-test.yml` that sets up a test environment,
   installs dependencies, and runs the Go tests (including race
   detection) on pull requests to the `main` branch.

These changes are made to improve the test coverage and ensure the
reliability of the obfuscation functionality, as well as to
automatically run the tests on pull requests to the main branch.