### PR TITLE
feat(obfuscator): Optimize obfuscation performance by reusing cached data

### DIFF
--- a/obfuscator_test.go
+++ b/obfuscator_test.go
@@ -38,7 +38,7 @@ func TestNewObfuscator_MultipleObfuscations(t *testing.T) {
 
 	// Act & Assert
 	// Thực hiện obfuscate nhiều lần
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		result, err := obf.Obfuscate(jsCode)
 		assert.NoError(t, err, "Obfuscation #%d không nên có lỗi", i+1)
 		assert.NotEmpty(t, result, "Kết quả obfuscation #%d không nên rỗng", i+1)


### PR DESCRIPTION
The changes made in this commit optimize the performance of the obfuscation process by reusing the cached data from previous obfuscations. The key changes are:

1. Removed the `cache` parameter from the `setupJSCode` function, as the cached data is now stored in the `Obfuscator` struct.
2. Updated the `NewObfuscator` function to call `setupJSCode` without a cache parameter, as the cache will be initialized later.
3. Updated the `Obfuscate` function to use the cached data if it is available, instead of creating a new cache for each obfuscation.
4. Simplified the `TestNewObfuscator_MultipleObfuscations` test by using a range loop instead of a hardcoded number of iterations.

These changes should improve the overall performance of the obfuscation process, especially when performing multiple obfuscations on the same code.