### PR TITLE
feat(obfuscator): Implement obfuscation level configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/naicoi92/obfuscator
+module gitlab.com/naicoi92/obfuscator
 
 go 1.24.0
 

--- a/obfuscator.go
+++ b/obfuscator.go
@@ -15,23 +15,10 @@ import (
 //go:embed obfuscation.js
 var JsCode string
 
-// Default options for JavaScript obfuscation
-const defaultOptions = `
-const options = {
-    compact: (Math.random() < 0.5),
-    controlFlowFlattening: true,
-    controlFlowFlatteningThreshold: 1,
-    numbersToExpressions: true,
-    simplify: true,
-    stringArrayShuffle: true,
-    splitStrings: true,
-    stringArrayThreshold: 1
-}
-`
-
 // Obfuscator represents a JavaScript obfuscator instance
 type Obfuscator struct {
 	CachedData *v8go.CompilerCachedData
+	Level      ObfuscationLevel
 }
 
 // NewObfuscator creates and initializes a new JavaScript obfuscator
@@ -40,7 +27,9 @@ func NewObfuscator() (*Obfuscator, error) {
 	defer isolate.Dispose()
 	context := v8go.NewContext(isolate)
 	defer context.Close()
-	o := &Obfuscator{}
+	o := &Obfuscator{
+		Level: DefaultLevel,
+	}
 	if err := o.setupJSCode(isolate, context); err != nil {
 		return nil, fmt.Errorf("failed to setup JS code: %w", err)
 	}
@@ -82,6 +71,10 @@ func (o *Obfuscator) setupJSCode(
 	return nil
 }
 
+func (o *Obfuscator) SetLevel(level ObfuscationLevel) {
+	o.Level = level
+}
+
 // Obfuscate transforms the provided JavaScript code using the obfuscator
 func (o *Obfuscator) Obfuscate(code string) (string, error) {
 	// Escape backticks in the input code to prevent JavaScript template literal issues
@@ -95,10 +88,11 @@ func (o *Obfuscator) Obfuscate(code string) (string, error) {
 	if err := o.setupJSCode(isolate, context); err != nil {
 		return "", fmt.Errorf("failed to setup JS code: %w", err)
 	}
+	options := getOptions(o.Level)
 	codeString := fmt.Sprintf(
 		"const code = `%s`; %s ;const obfuscatedCode = JavaScriptObfuscator.obfuscate(code, options).getObfuscatedCode();obfuscatedCode;",
 		code,
-		defaultOptions,
+		options,
 	)
 	val, err := context.RunScript(codeString, "run.js")
 	if err != nil {

--- a/obfuscator.go
+++ b/obfuscator.go
@@ -71,8 +71,8 @@ func (o *Obfuscator) setupJSCode(
 	return nil
 }
 
-func (o *Obfuscator) SetLevel(level ObfuscationLevel) {
-	o.Level = level
+func (o *Obfuscator) SetLevel(level string) {
+	o.Level = ObfuscationLevel(level)
 }
 
 // Obfuscate transforms the provided JavaScript code using the obfuscator

--- a/options.go
+++ b/options.go
@@ -1,0 +1,139 @@
+package obfuscator
+
+type ObfuscationLevel string
+
+var (
+	// DefaultLevel is the default obfuscation ObfuscationLevel
+	DefaultLevel ObfuscationLevel = "default"
+	// LowLevel is the low obfuscation ObfuscationLevel
+	LowLevel ObfuscationLevel = "low"
+	// MediumLevel is the medium obfuscation ObfuscationLevel
+	MediumLevel ObfuscationLevel = "medium"
+	// HighLevel is the high obfuscation ObfuscationLevel
+	HighLevel ObfuscationLevel = "high"
+)
+
+func getOptions(level ObfuscationLevel) string {
+	switch level {
+	case LowLevel:
+		return lowOptions
+	case MediumLevel:
+		return mediumOptions
+	case HighLevel:
+		return highOptions
+	default:
+		return defaultOptions
+	}
+}
+
+// Default options for JavaScript obfuscation
+const defaultOptions = `
+const options = {
+    compact: (Math.random() < 0.5),
+    controlFlowFlattening: true,
+    controlFlowFlatteningThreshold: 1,
+    numbersToExpressions: true,
+    simplify: true,
+    stringArrayShuffle: true,
+    splitStrings: true,
+    stringArrayThreshold: 1
+}
+`
+
+const lowOptions = `
+const options = {
+    compact: (Math.random() < 0.5),
+    controlFlowFlattening: false,
+    deadCodeInjection: false,
+    debugProtection: false,
+    debugProtectionInterval: 0,
+    disableConsoleOutput: true,
+    identifierNamesGenerator: 'hexadecimal',
+    log: false,
+    numbersToExpressions: false,
+    renameGlobals: false,
+    selfDefending: true,
+    simplify: true,
+    splitStrings: false,
+    stringArray: true,
+    stringArrayCallsTransform: false,
+    stringArrayEncoding: [],
+    stringArrayIndexShift: true,
+    stringArrayRotate: true,
+    stringArrayShuffle: true,
+    stringArrayWrappersCount: 1,
+    stringArrayWrappersChainedCalls: true,
+    stringArrayWrappersParametersMaxCount: 2,
+    stringArrayWrappersType: 'variable',
+    stringArrayThreshold: 0.75,
+    unicodeEscapeSequence: false
+}
+`
+
+const mediumOptions = `
+const options = {
+    compact: (Math.random() < 0.5),
+    controlFlowFlattening: true,
+    controlFlowFlatteningThreshold: 0.75,
+    deadCodeInjection: true,
+    deadCodeInjectionThreshold: 0.4,
+    debugProtection: false,
+    debugProtectionInterval: 0,
+    disableConsoleOutput: true,
+    identifierNamesGenerator: 'hexadecimal',
+    log: false,
+    numbersToExpressions: true,
+    renameGlobals: false,
+    selfDefending: true,
+    simplify: true,
+    splitStrings: true,
+    splitStringsChunkLength: 10,
+    stringArray: true,
+    stringArrayCallsTransform: true,
+    stringArrayCallsTransformThreshold: 0.75,
+    stringArrayEncoding: ['base64'],
+    stringArrayIndexShift: true,
+    stringArrayRotate: true,
+    stringArrayShuffle: true,
+    stringArrayWrappersCount: 2,
+    stringArrayWrappersChainedCalls: true,
+    stringArrayWrappersParametersMaxCount: 4,
+    stringArrayWrappersType: 'function',
+    stringArrayThreshold: 0.75,
+    transformObjectKeys: true,
+    unicodeEscapeSequence: false
+}`
+
+const highOptions = `
+const options = {
+    compact: (Math.random() < 0.5),
+    controlFlowFlattening: true,
+    controlFlowFlatteningThreshold: 1,
+    deadCodeInjection: true,
+    deadCodeInjectionThreshold: 1,
+    debugProtection: true,
+    debugProtectionInterval: 4000,
+    disableConsoleOutput: true,
+    identifierNamesGenerator: 'hexadecimal',
+    log: false,
+    numbersToExpressions: true,
+    renameGlobals: false,
+    selfDefending: true,
+    simplify: true,
+    splitStrings: true,
+    splitStringsChunkLength: 5,
+    stringArray: true,
+    stringArrayCallsTransform: true,
+    stringArrayEncoding: ['rc4'],
+    stringArrayIndexShift: true,
+    stringArrayRotate: true,
+    stringArrayShuffle: true,
+    stringArrayWrappersCount: 5,
+    stringArrayWrappersChainedCalls: true,    
+    stringArrayWrappersParametersMaxCount: 5,
+    stringArrayWrappersType: 'function',
+    stringArrayThreshold: 1,
+    transformObjectKeys: true,
+    unicodeEscapeSequence: false
+}
+`


### PR DESCRIPTION
This change adds the ability to configure the obfuscation level for the
JavaScript obfuscator. The new `SetLevel` method allows setting the
obfuscation level, which determines the options used for obfuscation.

The available obfuscation levels are:
- `DefaultLevel`: The default obfuscation level
- `LowLevel`: A low level of obfuscation
- `MediumLevel`: A medium level of obfuscation
- `HighLevel`: A high level of obfuscation

The commit also updates the `Obfuscate` method to use the appropriate
obfuscation options based on the configured level.